### PR TITLE
Add Kotlin Multiplatform module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 ios/build
 android/app/build
+kmm/build
+kmm/.gradle

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Job Search App
 
-This repository contains a minimal React Native project for a job search application.
-It now also includes example Swift projects demonstrating basic iOS and macOS apps.
+This repository started as a minimal React Native project for a job search application.
+It now also includes a simple Kotlin Multiplatform Mobile (KMM) module and example Swift projects for iOS and macOS.
 
 ## Getting Started
 
@@ -18,6 +18,19 @@ It now also includes example Swift projects demonstrating basic iOS and macOS ap
    ```bash
    npm run ios
    ```
+
+### Kotlin Multiplatform
+
+The `kmm` directory contains a basic Kotlin Multiplatform project. To build the
+shared framework for the iOS simulator on macOS run:
+
+```bash
+cd kmm
+./gradlew :shared:assembleIosSimulatorArm64DebugFramework
+```
+
+The generated framework can then be opened with Xcode and executed in the iOS
+emulator.
 
 ## Project Structure
 

--- a/kmm/README.md
+++ b/kmm/README.md
@@ -1,0 +1,13 @@
+# Kotlin Multiplatform Module
+
+This folder contains a minimal Kotlin Multiplatform project. The `shared` module compiles to a framework that can run on iOS and Android.
+
+## Building for iOS
+
+From a macOS machine run:
+
+```bash
+./gradlew :shared:assembleIosSimulatorArm64DebugFramework
+```
+
+The resulting framework can be opened with Xcode and run in the iOS simulator.

--- a/kmm/build.gradle.kts
+++ b/kmm/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    kotlin("multiplatform") version "2.0.21" apply false
+    id("com.android.application") version "8.4.0" apply false
+}

--- a/kmm/settings.gradle.kts
+++ b/kmm/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "JobSearchKMM"
+include("shared")

--- a/kmm/shared/build.gradle.kts
+++ b/kmm/shared/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    android()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        val commonMain by getting {
+        }
+        val commonTest by getting
+        val androidMain by getting
+        val iosX64Main by getting
+        val iosArm64Main by getting
+        val iosSimulatorArm64Main by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
+            iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
+        }
+    }
+}

--- a/kmm/shared/src/androidMain/kotlin/com/example/jobsearchkmm/Platform.kt
+++ b/kmm/shared/src/androidMain/kotlin/com/example/jobsearchkmm/Platform.kt
@@ -1,0 +1,5 @@
+package com.example.jobsearchkmm
+
+actual class Platform actual constructor() {
+    actual val name: String = "Android"
+}

--- a/kmm/shared/src/commonMain/kotlin/com/example/jobsearchkmm/Greeting.kt
+++ b/kmm/shared/src/commonMain/kotlin/com/example/jobsearchkmm/Greeting.kt
@@ -1,0 +1,5 @@
+package com.example.jobsearchkmm
+
+class Greeting {
+    fun greet(): String = "Hello, Kotlin Multiplatform!"
+}

--- a/kmm/shared/src/commonMain/kotlin/com/example/jobsearchkmm/Platform.kt
+++ b/kmm/shared/src/commonMain/kotlin/com/example/jobsearchkmm/Platform.kt
@@ -1,0 +1,5 @@
+package com.example.jobsearchkmm
+
+expect class Platform() {
+    val name: String
+}

--- a/kmm/shared/src/iosMain/kotlin/com/example/jobsearchkmm/Platform.kt
+++ b/kmm/shared/src/iosMain/kotlin/com/example/jobsearchkmm/Platform.kt
@@ -1,0 +1,7 @@
+package com.example.jobsearchkmm
+
+import platform.UIKit.UIDevice
+
+actual class Platform actual constructor() {
+    actual val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+}


### PR DESCRIPTION
## Summary
- add Kotlin Multiplatform sample under `kmm`
- ignore build files for the new module
- document how to build the KMM framework

## Testing
- `npm test` *(fails: Missing script)*
- `gradle tasks` in `kmm` *(fails: plugin not found because repositories are offline)*

------
https://chatgpt.com/codex/tasks/task_e_68441c2d35e08332a95f604d8d63c740