### PR TITLE
Handle Bundes API location object

### DIFF
--- a/JobwasilAPI.d.ts
+++ b/JobwasilAPI.d.ts
@@ -1,0 +1,18 @@
+export interface Arbeitsort {
+  plz?: string;
+  ort?: string;
+  strasse?: string | null;
+  region?: string | null;
+  land?: string | null;
+  koordinaten?: { lat?: number; lon?: number } | null;
+}
+
+export interface Job {
+  titel?: string;
+  title?: string;
+  berufsbezeichnung?: string;
+  arbeitsort?: Arbeitsort;
+  ort?: string;
+  location?: string;
+  [key: string]: any;
+}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,9 +2,16 @@ import React, { useEffect, useState } from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
 import { ActivityIndicator, Card } from 'react-native-paper';
 import { fetchJobs } from '@/services/BundesApi';
+import type { Job } from '@/JobwasilAPI';
+
+function formatArbeitsort(arbeitsort?: Job['arbeitsort']): string {
+  if (!arbeitsort) return '';
+  const { ort, plz } = arbeitsort;
+  return `${ort ?? ''} ${plz ?? ''}`.trim();
+}
 
 export default function HomeScreen() {
-  const [jobs, setJobs] = useState<any[]>([]);
+  const [jobs, setJobs] = useState<Job[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -33,7 +40,11 @@ export default function HomeScreen() {
           <Card key={idx} style={styles.card}>
             <Card.Title
               title={job.berufsbezeichnung || job.titel || job.title}
-              subtitle={job.arbeitsort || job.ort || job.location}
+              subtitle={
+                job.arbeitsort
+                  ? formatArbeitsort(job.arbeitsort)
+                  : job.ort || job.location || ''
+              }
             />
           </Card>
         ))


### PR DESCRIPTION
## Summary
- define Job and Arbeitsort types
- format `arbeitsort` object to a readable string in Home screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684971082d988332ab9dbeefb0aa62e0