### PR TITLE
Clean up Jobwasil logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Assets
+
+Place a custom Jobwasil logo at `assets/jobwasil/jobwasil-magician.png` to show it in the app.
+


### PR DESCRIPTION
## Summary
- remove unsupported `jobwasil-magician.png`
- restore original home screen layout without the logo
- add placeholder folder at `assets/jobwasil/` for a custom logo
- document the new asset path in README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f032c1c08332a4bc44571eb5d5a1